### PR TITLE
Ignore patterns & customizable decorator string

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,16 @@
           "type": "string",
           "default": "",
           "description": "Specify a color (like #00FF00) to override the color of prerelease upgrades. Leave empty for default color."
+        },
+        "package-json-upgrade.decorationString": {
+          "type": "string",
+          "default": "\t\tUpdate available: %s",
+          "description": "Customize update string. %s will be replaced by version, so 'Update: %s' will result in 'Update: 1.0.1'."
+        },
+        "package-json-upgrade.ignorePatterns": {
+          "type": "array",
+          "default": [],
+          "description": "Regex pattern of packages to not show decoration string for. To ignore all material-ui packages the JSON should be [\"^(?=@material-ui).+$\"]"
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ interface Config {
   patchUpgradeColorOverwrite: string
   prereleaseUpgradeColorOverwrite: string
   ignorePatterns: string[]
+  decorationString: string
 }
 
 let currentConfig: Config | undefined
@@ -29,6 +30,7 @@ export const reloadConfig = () => {
     minorUpgradeColorOverwrite: config.get<string>('minorUpgradeColorOverwrite') ?? '',
     patchUpgradeColorOverwrite: config.get<string>('patchUpgradeColorOverwrite') ?? '',
     prereleaseUpgradeColorOverwrite: config.get<string>('prereleaseUpgradeColorOverwrite') ?? '',
+    decorationString: config.get<string>('decorationString') ?? '\t\tUpdate available: %s',
   }
 
   currentConfig = newConfig

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,8 @@ export const reloadConfig = () => {
     minorUpgradeColorOverwrite: config.get<string>('minorUpgradeColorOverwrite') ?? '',
     patchUpgradeColorOverwrite: config.get<string>('patchUpgradeColorOverwrite') ?? '',
     prereleaseUpgradeColorOverwrite: config.get<string>('prereleaseUpgradeColorOverwrite') ?? '',
-    decorationString: config.get<string>('decorationString') ?? '\t\tUpdate available: %s',
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    decorationString: config.get<string>('decorationString') || '\t\tUpdate available: %s',
   }
 
   currentConfig = newConfig

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ interface Config {
   minorUpgradeColorOverwrite: string
   patchUpgradeColorOverwrite: string
   prereleaseUpgradeColorOverwrite: string
+  ignorePatterns: string[]
 }
 
 let currentConfig: Config | undefined
@@ -21,6 +22,7 @@ export const getConfig = (): Config => {
 export const reloadConfig = () => {
   const config = vscode.workspace.getConfiguration('package-json-upgrade')
   const newConfig: Config = {
+    ignorePatterns: config.get<string[]>('ignorePatterns') ?? [],
     showUpdatesAtStart: config.get<boolean>('showUpdatesAtStart') === true,
     skipNpmConfig: config.get<boolean>('skipNpmConfig') === true,
     majorUpgradeColorOverwrite: config.get<string>('majorUpgradeColorOverwrite') ?? '',

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -99,17 +99,21 @@ export const getDecoratorForUpdate = (
   switch (releaseType) {
     case 'major':
     case 'premajor':
-      return decorateMajorUpdate(`\t\tUpdate available: ${latestVersion}`)
+      return decorateMajorUpdate(getUpdateDescription(latestVersion))
     case 'minor':
     case 'preminor':
-      return decorateMinorUpdate(`\t\tUpdate available: ${latestVersion}`)
+      return decorateMinorUpdate(getUpdateDescription(latestVersion))
     case 'patch':
     case 'prepatch':
-      return decoratePatchUpdate(`\t\tUpdate available: ${latestVersion}`)
+      return decoratePatchUpdate(getUpdateDescription(latestVersion))
     case 'prerelease':
-      return decoratePrereleaseUpdate(`\t\tUpdate available: ${latestVersion}`)
+      return decoratePrereleaseUpdate(getUpdateDescription(latestVersion))
     case null:
     default:
       return undefined
   }
+}
+
+function getUpdateDescription(latestVersion: string): string {
+  return getConfig().decorationString.replace('%s', latestVersion)
 }

--- a/src/texteditor.ts
+++ b/src/texteditor.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import { getConfig } from './config'
 import { decorateDiscreet, getDecoratorForUpdate } from './decorations'
 import { getCachedNpmData, getPossibleUpgrades, refreshPackageJsonData } from './npm'
 import { parseDependencyLine } from './packageJson'
@@ -56,6 +57,8 @@ const updatePackageJson = async (document: vscode.TextDocument) => {
 
   await refreshPackageJsonData(document)
 
+  const ignorePatterns = getConfig().ignorePatterns.map((pattern) => new RegExp(pattern))
+
   clearCurrentDecorations()
 
   Array.from({ length: document.lineCount })
@@ -71,6 +74,12 @@ const updatePackageJson = async (document: vscode.TextDocument) => {
 
       if (dep === undefined) {
         return
+      }
+
+      for (const ignorePattern of ignorePatterns) {
+        if (ignorePattern.exec(dep.dependencyName) !== null) {
+          return
+        }
       }
 
       const range = new vscode.Range(

--- a/src/texteditor.ts
+++ b/src/texteditor.ts
@@ -57,7 +57,16 @@ const updatePackageJson = async (document: vscode.TextDocument) => {
 
   await refreshPackageJsonData(document)
 
-  const ignorePatterns = getConfig().ignorePatterns.map((pattern) => new RegExp(pattern))
+  const ignorePatterns: RegExp[] = []
+  for (const pattern of getConfig().ignorePatterns) {
+    try {
+      ignorePatterns.push(new RegExp(pattern))
+    } catch (err) {
+      vscode.window.showErrorMessage(
+        `Invalid ignore pattern ${pattern}${err instanceof Error ? `: ${err.message}` : ``}`,
+      )
+    }
+  }
 
   clearCurrentDecorations()
 


### PR DESCRIPTION
Hi there!  Thanks for the great package.  I really like how it's much less intrusive than the code lens package json plugin.

For my use case, I really only care about seeing updates for my own monorepo packages, so I took a stab and implemented the requested feature from https://github.com/pgsandstrom/package-json-upgrade/issues/17 that you seemed to like, although not exactly as the OP suggested.  I made it so you can have an array of _ignore patterns_, like so:

```json
{
  "package-json-upgrade.ignorePatterns": [
    "^(?!@friends-library).+$"
  ],
}
```

Works great and seems flexible enough to support most use-cases.

And then (in hindsight maybe I should have separated this out into a separate PR, sorry, let me know if you want me to do that), I wanted to customize the string output to be more subtle, what I was going for was this:

![2021-06-14_12-00-37](https://user-images.githubusercontent.com/7050938/121922646-28085800-cd08-11eb-8fd7-f03f9a2d8350.png)

So I quick implemented a feature allowing customization of the default `Update available for: <semver>`, allowing this in the settings:

```json
{
  "package-json-upgrade.decorationString": "%s",
}
```

I used a C/printf style placeholder of `%s` to represent where to put the semver string, as you can see in the code.

I can write up a bit of documentation on these options in the readme, if you are up for merging.  Thanks again!