### PR TITLE
Add `showOverviewRulerColor` configuration option

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
           "default": true,
           "description": "Available updates will be shown directly when a package.json is opened. Otherwise, this must be toggled with a command."
         },
+        "package-json-upgrade.showOverviewRulerColor": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show color indicators on the scrollbar for available updates."
+        },
         "package-json-upgrade.skipNpmConfig": {
           "type": "boolean",
           "default": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 export interface Config {
   showUpdatesAtStart: boolean
+  showOverviewRulerColor: boolean
   skipNpmConfig: boolean
   majorUpgradeColorOverwrite: string
   minorUpgradeColorOverwrite: string

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -1,5 +1,6 @@
 import { ReleaseType } from 'semver'
 import {
+  DecorationRenderOptions,
   OverviewRulerLane,
   TextEditorDecorationType,
   ThemableDecorationRenderOptions,
@@ -20,17 +21,23 @@ const decorateUpdatedPackage = ({
   dark,
   contentText,
 }: DecorationTypeConfigurables) => {
-  return window.createTextEditorDecorationType({
+  const config = getConfig()
+  const decorationType: DecorationRenderOptions = {
     isWholeLine: false,
-    overviewRulerLane: OverviewRulerLane.Right,
     after: {
       margin: '2em',
       contentText,
     },
-    overviewRulerColor,
     light,
     dark,
-  })
+  }
+
+  if (config.showOverviewRulerColor) {
+    decorationType.overviewRulerLane = OverviewRulerLane.Right
+    decorationType.overviewRulerColor = overviewRulerColor
+  }
+
+  return window.createTextEditorDecorationType(decorationType)
 }
 
 const decorateMajorUpdate = (contentText: string) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,6 +122,7 @@ const fixConfig = () => {
   const workspaceConfig = vscode.workspace.getConfiguration('package-json-upgrade')
   const config: Config = {
     showUpdatesAtStart: workspaceConfig.get<boolean>('showUpdatesAtStart') === true,
+    showOverviewRulerColor: workspaceConfig.get<boolean>('showOverviewRulerColor') === true,
     skipNpmConfig: workspaceConfig.get<boolean>('skipNpmConfig') === true,
     majorUpgradeColorOverwrite: workspaceConfig.get<string>('majorUpgradeColorOverwrite') ?? '',
     minorUpgradeColorOverwrite: workspaceConfig.get<string>('minorUpgradeColorOverwrite') ?? '',

--- a/src/test-jest/npm.test.ts
+++ b/src/test-jest/npm.test.ts
@@ -66,6 +66,7 @@ describe('Npm Test Suite', () => {
   beforeAll(() => {
     const config: Config = {
       showUpdatesAtStart: true,
+      showOverviewRulerColor: true,
       skipNpmConfig: true,
       majorUpgradeColorOverwrite: '',
       minorUpgradeColorOverwrite: '',

--- a/src/test-vscode/updateAll.test.ts
+++ b/src/test-vscode/updateAll.test.ts
@@ -64,6 +64,7 @@ suite('UpdateAll Test Suite', () => {
   test('When all releases are prereleases', async function () {
     const config: Config = {
       showUpdatesAtStart: true,
+      showOverviewRulerColor: true,
       skipNpmConfig: true,
       majorUpgradeColorOverwrite: '',
       minorUpgradeColorOverwrite: '',


### PR DESCRIPTION
Hello 👋

Thank you very much for the extension, it's exactly what I was looking for, you did a great job! However, I'm kinda "minimalistic" person and love when my VSCode is less distracting. So, I thought, it would be nice to have an option disable those bright overview ruler colors. Don't worry, by default it will be enabled and users won't notice any differences! 😊

**Changelog**
- Added `showOverviewRulerColor` configuration option, using `package-json-upgrade.showOverviewRulerColor` you can disable or enable overview ruler colors.

<details>
<summary>Before 👀</summary>
<img width="1709" alt="Screenshot 2024-08-25 at 22 26 02" src="https://github.com/user-attachments/assets/698cf7fb-fc7e-49a4-bb02-ba10b27d17ad">
</details>

<details>
<summary>After 👀</summary>
<img width="1709" alt="Screenshot 2024-08-25 at 22 26 42" src="https://github.com/user-attachments/assets/35aefe3f-52ed-4b02-be0f-9593910524ab">
</details>