### PR TITLE
Improve package.json support

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -13,8 +13,12 @@ export interface NpmLoader<T> {
 }
 
 interface PackageJson {
-  dependencies: StrictDict<string, PackageJsonDependency>
-  devDependencies: StrictDict<string, PackageJsonDependency>
+  dependencies?: StrictDict<string, PackageJsonDependency>
+  devDependencies?: StrictDict<string, PackageJsonDependency>
+  peerDependencies?: StrictDict<string, PackageJsonDependency>
+  optionalDependencies?: StrictDict<string, PackageJsonDependency>
+  overrides?: StrictDict<string, PackageJsonDependency>
+  resolutions?: StrictDict<string, PackageJsonDependency>
 }
 
 interface PackageJsonDependency {
@@ -258,10 +262,14 @@ export const refreshPackageJsonData = (
     const dependencies = {
       ...json.dependencies,
       ...json.devDependencies,
+      ...json.peerDependencies,
+      ...json.optionalDependencies,
+      ...json.overrides,
+      ...json.resolutions,
     }
 
-    const promises = Object.entries(dependencies)
-      .map(([dependencyName, _version]) => {
+    const promises = Object.keys(dependencies)
+      .map((dependencyName) => {
         const cache = npmCache[dependencyName]
         if (
           cache === undefined ||

--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -3,6 +3,15 @@ import { parse } from '@typescript-eslint/parser'
 import { TSESTree } from '@typescript-eslint/types'
 import { VariableDeclaration } from '@typescript-eslint/types/dist/generated/ast-spec'
 
+const DEPENDENCY_KEYS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+  'overrides',
+  'resolutions', // yarn
+]
+
 export interface DependencyGroups {
   startLine: number
   deps: Dependency[]
@@ -40,16 +49,8 @@ export const getDependencyInformation = (jsonAsString: string): DependencyGroups
 
   const properties = init.properties as TSESTree.Property[]
 
-  const dependencies = properties.find(
-    (p) => (p.key as TSESTree.StringLiteral).value === 'dependencies',
-  )
-
-  const devDependencies = properties.find(
-    (p) => (p.key as TSESTree.StringLiteral).value === 'devDependencies',
-  )
-
-  return [dependencies, devDependencies]
-    .filter((i): i is TSESTree.Property => i !== undefined)
+  return properties
+    .filter((p) => DEPENDENCY_KEYS.includes((p.key as TSESTree.StringLiteral).value))
     .map(toDependencyGroup)
 }
 


### PR DESCRIPTION
Adds support for `peerDependencies`, `optionalDependencies`, `overrides` and yarn `resolutions`.

Still missing support for `pnpm.overrides`.