### PR TITLE
Add catalog support for workspace dependency management

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
         },
         "package-json-upgrade.dependencyGroups": {
           "type": "string",
-          "default": "dependencies, devDependencies, catalog",
-          "description": "Comma-separated list of dependency groups to check for updates. Default is 'dependencies, devDependencies'. Add 'peerDependencies', 'optionalDependencies', etc. as needed."
+          "default": "dependencies, devDependencies, catalog, catalogs, workspaces.catalog, workspaces.catalogs",
+          "description": "Comma-separated list of dependency groups to check for updates. Default includes common dependency groups and catalog groups. Add 'peerDependencies', 'optionalDependencies', etc. as needed."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         },
         "package-json-upgrade.dependencyGroups": {
           "type": "string",
-          "default": "dependencies, devDependencies",
+          "default": "dependencies, devDependencies, catalog",
           "description": "Comma-separated list of dependency groups to check for updates. Default is 'dependencies, devDependencies'. Add 'peerDependencies', 'optionalDependencies', etc. as needed."
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,7 +157,8 @@ const fixConfig = () => {
       workspaceConfig.get<Record<string, string | undefined | string[]>>('ignoreVersions') ?? {},
     msUntilRowLoading: workspaceConfig.get<number>('msUntilRowLoading') ?? 0,
     dependencyGroups: (
-      workspaceConfig.get<string>('dependencyGroups') ?? 'dependencies, devDependencies'
+      workspaceConfig.get<string>('dependencyGroups') ??
+      'dependencies, devDependencies, catalog, catalogs, workspaces.catalog, workspaces.catalogs'
     )
       .split(',')
       .map((s) => s.trim())

--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -54,9 +54,14 @@ function toDependencyGroup(jsonAsString: string, dependencyNode: Node): Dependen
       return null
     }
 
+    const version = valueNode.value as string
+    if (version.startsWith('catalog:')) {
+      return null
+    }
+
     return {
       dependencyName: keyNode.value as string,
-      currentVersion: valueNode.value as string,
+      currentVersion: version,
       line: offsetToLine(jsonAsString, property.offset),
     }
   })

--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -32,7 +32,7 @@ export const getDependencyInformation = (jsonAsString: string): DependencyGroups
   const groups = getConfig().dependencyGroups
 
   return groups
-    .map((group) => findNodeAtLocation(tree, [group]))
+    .map((group) => findNodeAtLocation(tree, toPath(group)))
     .filter((node): node is Node => node !== undefined)
     .map((node) => toDependencyGroup(jsonAsString, node))
 }
@@ -42,34 +42,70 @@ function toDependencyGroup(jsonAsString: string, dependencyNode: Node): Dependen
     return { startLine: 0, deps: [] }
   }
 
-  const deps = dependencyNode.children.map((property) => {
-    if (property.type !== 'property' || !property.children || property.children.length < 2) {
-      return null
-    }
-
-    const keyNode = property.children[0]
-    const valueNode = property.children[1]
-
-    if (keyNode.type !== 'string' || valueNode.type !== 'string') {
-      return null
-    }
-
-    const version = valueNode.value as string
-    if (version.startsWith('catalog:')) {
-      return null
-    }
-
-    return {
-      dependencyName: keyNode.value as string,
-      currentVersion: version,
-      line: offsetToLine(jsonAsString, property.offset),
-    }
-  })
+  const deps = dependencyNode.children.flatMap((property) =>
+    getDependenciesFromProperty(jsonAsString, property),
+  )
 
   return {
     startLine: offsetToLine(jsonAsString, dependencyNode.offset),
-    deps: deps.filter((d): d is Dependency => d !== null),
+    deps,
   }
+}
+
+function getDependenciesFromProperty(jsonAsString: string, property: Node): Dependency[] {
+  if (property.type !== 'property' || !property.children || property.children.length < 2) {
+    return []
+  }
+
+  const keyNode = property.children[0]
+  const valueNode = property.children[1]
+
+  if (keyNode.type !== 'string') {
+    return []
+  }
+
+  if (valueNode.type === 'string') {
+    const dependency = toDependency(
+      jsonAsString,
+      keyNode.value as string,
+      valueNode.value as string,
+      property.offset,
+    )
+    return dependency === null ? [] : [dependency]
+  }
+
+  // catalogs is an object where each property is itself a dependency object.
+  if (valueNode.type === 'object' && valueNode.children) {
+    return valueNode.children.flatMap((nestedProperty) =>
+      getDependenciesFromProperty(jsonAsString, nestedProperty),
+    )
+  }
+
+  return []
+}
+
+function toDependency(
+  jsonAsString: string,
+  dependencyName: string,
+  version: string,
+  offset: number,
+): Dependency | null {
+  if (version.startsWith('catalog:')) {
+    return null
+  }
+
+  return {
+    dependencyName,
+    currentVersion: version,
+    line: offsetToLine(jsonAsString, offset),
+  }
+}
+
+function toPath(group: string): string[] {
+  return group
+    .split('.')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
 }
 
 // jsonc-parser gives offset in characters, so we have to translate it to line numbers


### PR DESCRIPTION
Add support for the catalog section in package.json, used by pnpm, yarn, and bun workspaces to centralize shared dependency versions.

Changes:

Expand default dependencyGroups to include:
- catalog
- catalogs
- workspaces.catalog
- workspaces.catalogs
- Support dot-path dependency group lookup (for nested groups like workspaces.catalogs)
- Parse catalogs objects with arbitrarily named catalogs (for example catalogs.default, catalogs.react17)
- Update refresh/fetch dependency collection to flatten nested catalog maps into real dependency/version pairs, instead of treating catalog names as dependencies
- Align runtime fallback defaults with contributed setting defaults for dependencyGroups
- Skip dependencies with `catalog:` version references (e.g. `"catalog:"`, `"catalog:default"`) to avoid "Failed to parse version" decorations on workspace packages that reference the catalog
- Add test coverage for:
    - catalog + catalog: filtering
    - catalogs with arbitrary names
    - nested workspaces.catalog and workspaces.catalogs parsing/filtering

Resources:
- https://pnpm.io/catalogs
- https://yarnpkg.com/features/catalogs
- https://bun.sh/docs/pm/catalogs

Closes #62


<img width="785" height="456" alt="image" src="https://github.com/user-attachments/assets/e9fd0b66-5f2a-4775-a09a-cf361ed8b1b4" />
