### PR TITLE
feat: Support for minimum release age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "package-json-upgrade" extension will be documented i
 
 ## Unreleased changes
 
+## 3.6.0
+
+- Support for minimum release age gate. Added "minimumReleaseAge" and "minimumReleaseAgeExclude" configs.
+
 ## 3.5.0
 
 - Added catalog support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "package-json-upgrade",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "package-json-upgrade",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@pnpm/npm-conf": "3.0.2",
@@ -1593,6 +1593,7 @@
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1722,6 +1723,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2490,6 +2492,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2574,6 +2577,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2858,6 +2862,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3962,6 +3967,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8691,6 +8697,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8901,6 +8908,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9151,6 +9159,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9200,6 +9209,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1539,6 +1539,7 @@
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1668,6 +1669,7 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -2428,6 +2430,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2512,6 +2515,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2811,6 +2815,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3898,6 +3903,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8518,6 +8524,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8727,6 +8734,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8977,6 +8985,7 @@
       "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "package-json-upgrade",
   "displayName": "Package Json Upgrade",
   "description": "Shows available updates in package.json files. Offers quick fix command to update them and to show the changelog.",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "publisher": "codeandstuff",
   "license": "MIT",
   "icon": "logo/icon.webp",
@@ -93,6 +93,16 @@
           "type": "string",
           "default": "dependencies, devDependencies, catalog, catalogs, workspaces.catalog, workspaces.catalogs",
           "description": "Comma-separated list of dependency groups to check for updates. Default includes common dependency groups and catalog groups. Add 'peerDependencies', 'optionalDependencies', etc. as needed."
+        },
+        "package-json-upgrade.minimumReleaseAge": {
+          "type": "number",
+          "default": 0,
+          "description": "Mirrors npm's minimumReleaseAge. Hide upgrades to versions published less than this many minutes ago. When the newest version is held back, the decoration shows the highest eligible upgrade and the true latest (e.g. '5.1.0 (latest 5.2.0)'). 0 to disable."
+        },
+        "package-json-upgrade.minimumReleaseAgeExclude": {
+          "type": "array",
+          "default": [],
+          "description": "Package names to exclude from the minimumReleaseAge check. For example [\"@my-org/some-package\"] to always show the newest version regardless of release age."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,6 +93,16 @@
           "type": "string",
           "default": "dependencies, devDependencies, catalog, catalogs, workspaces.catalog, workspaces.catalogs",
           "description": "Comma-separated list of dependency groups to check for updates. Default includes common dependency groups and catalog groups. Add 'peerDependencies', 'optionalDependencies', etc. as needed."
+        },
+        "package-json-upgrade.minimumReleaseAge": {
+          "type": "number",
+          "default": 0,
+          "description": "Mirrors npm's minimumReleaseAge. Hide upgrades to versions published less than this many minutes ago. When the newest version is held back, the decoration shows the highest eligible upgrade and the true latest (e.g. '5.1.0 (latest 5.2.0)'). 0 to disable."
+        },
+        "package-json-upgrade.minimumReleaseAgeExclude": {
+          "type": "array",
+          "default": [],
+          "description": "Package names to exclude from the minimumReleaseAge check. For example [\"@my-org/some-package\"] to always show the newest version regardless of release age."
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,8 @@ export interface Config {
   ignoreVersions: Record<string, string | undefined | string[]>
   msUntilRowLoading: number
   dependencyGroups: string[]
+  minimumReleaseAge: number
+  minimumReleaseAgeExclude: string[]
 }
 
 let currentConfig: Config | undefined

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -127,11 +127,16 @@ export const getDecoratorForUpdate = (
 export function getUpdateDescription(
   latestVersion: string,
   currentVersionExisting: boolean,
+  heldBackLatest?: string,
 ): string {
   const versionString = getConfig().decorationString.replace('%s', latestVersion)
+  const withHeldBack =
+    heldBackLatest !== undefined && heldBackLatest !== latestVersion
+      ? `${versionString} (latest ${heldBackLatest})`
+      : versionString
   if (currentVersionExisting) {
-    return versionString
+    return withHeldBack
   } else {
-    return `${versionString} (current version not found)`
+    return `${withHeldBack} (current version not found)`
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,6 +163,8 @@ const fixConfig = () => {
       .split(',')
       .map((s) => s.trim())
       .filter((s) => s.length > 0),
+    minimumReleaseAge: Math.max(0, workspaceConfig.get<number>('minimumReleaseAge') ?? 0),
+    minimumReleaseAgeExclude: workspaceConfig.get<string[]>('minimumReleaseAgeExclude') ?? [],
   }
   setConfig(config)
 }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -42,6 +42,10 @@ export interface NpmData {
         directory?: string
       }
     | string
+  // ISO-8601 publish timestamps keyed by version (plus 'created' / 'modified' entries).
+  time?: {
+    [key in string]: string
+  }
 }
 
 export interface VersionData {
@@ -54,6 +58,11 @@ export interface DependencyUpdateInfo {
   minor?: VersionData
   patch?: VersionData
   prerelease?: VersionData
+  // Per-bucket "true latest" — only set when higher than the eligible upgrade, i.e. held back by minimumReleaseAge.
+  majorLatest?: VersionData
+  minorLatest?: VersionData
+  patchLatest?: VersionData
+  prereleaseLatest?: VersionData
   validVersion: boolean // if the current version is valid semver
   existingVersion: boolean // if the current version exists
 }
@@ -81,17 +90,28 @@ export const setCachedNpmData = (newNpmCache: Dict<string, NpmLoader<CacheItem>>
   npmCache = newNpmCache
 }
 
+export interface ReleaseAgeFilter {
+  minimumReleaseAgeMinutes: number
+  excludedPackages: string[]
+  now?: number // override for tests; defaults to Date.now()
+}
+
 export const getLatestVersion = (
   npmData: NpmData,
   rawCurrentVersion: string,
   dependencyName: string,
 ): VersionData | undefined => {
-  const ignoredVersions = getConfig().ignoreVersions[dependencyName]
+  const config = getConfig()
+  const ignoredVersions = config.ignoreVersions[dependencyName]
   return getLatestVersionWithIgnoredVersions(
     npmData,
     rawCurrentVersion,
     dependencyName,
     ignoredVersions,
+    {
+      minimumReleaseAgeMinutes: config.minimumReleaseAge,
+      excludedPackages: config.minimumReleaseAgeExclude,
+    },
   )
 }
 
@@ -100,12 +120,14 @@ export const getLatestVersionWithIgnoredVersions = (
   rawCurrentVersion: string,
   dependencyName: string,
   ignoredVersions: string | undefined | string[],
+  ageFilter?: ReleaseAgeFilter,
 ): VersionData | undefined => {
   const possibleUpgrades = getPossibleUpgradesWithIgnoredVersions(
     npmData,
     rawCurrentVersion,
     dependencyName,
     ignoredVersions,
+    ageFilter,
   )
   return (
     possibleUpgrades.major ??
@@ -140,12 +162,17 @@ export const getPossibleUpgrades = (
   rawCurrentVersion: string,
   dependencyName: string,
 ): DependencyUpdateInfo => {
-  const ignoredVersions = getConfig().ignoreVersions[dependencyName]
+  const config = getConfig()
+  const ignoredVersions = config.ignoreVersions[dependencyName]
   return getPossibleUpgradesWithIgnoredVersions(
     npmData,
     rawCurrentVersion,
     dependencyName,
     ignoredVersions,
+    {
+      minimumReleaseAgeMinutes: config.minimumReleaseAge,
+      excludedPackages: config.minimumReleaseAgeExclude,
+    },
   )
 }
 
@@ -154,6 +181,7 @@ export const getPossibleUpgradesWithIgnoredVersions = (
   rawCurrentVersion: string,
   dependencyName: string,
   ignoredVersions: string | undefined | string[],
+  ageFilter?: ReleaseAgeFilter,
 ): DependencyUpdateInfo => {
   if (rawCurrentVersion === '*' || rawCurrentVersion === 'x') {
     return { validVersion: true, existingVersion: true }
@@ -183,8 +211,10 @@ export const getPossibleUpgradesWithIgnoredVersions = (
     coercedVersion,
   )
 
-  const helper = (releaseTypeList: ReleaseType[]) => {
-    const matchingUpgradeTypes = possibleUpgrades.filter((version) => {
+  const eligibleUpgrades = filterByReleaseAge(possibleUpgrades, npmData, dependencyName, ageFilter)
+
+  const pickHighest = (source: VersionData[], releaseTypeList: ReleaseType[]) => {
+    const matchingUpgradeTypes = source.filter((version) => {
       const diffType = diff(version.version, coercedVersion)
       return diffType !== null && releaseTypeList.includes(diffType)
     })
@@ -195,18 +225,80 @@ export const getPossibleUpgradesWithIgnoredVersions = (
 
   // If we are at a prerelease, then show all pre-x.
   // This is partially done to account for when there are only pre-x versions.
-  const majorUpgrade = helper(currentVersionIsPrerelease ? ['major', 'premajor'] : ['major'])
-  const minorUpgrade = helper(currentVersionIsPrerelease ? ['minor', 'preminor'] : ['minor'])
-  const patchUpgrade = helper(currentVersionIsPrerelease ? ['patch', 'prepatch'] : ['patch'])
-  const prereleaseUpgrade = currentVersionIsPrerelease ? helper(['prerelease']) : undefined
+  const majorTypes: ReleaseType[] = currentVersionIsPrerelease ? ['major', 'premajor'] : ['major']
+  const minorTypes: ReleaseType[] = currentVersionIsPrerelease ? ['minor', 'preminor'] : ['minor']
+  const patchTypes: ReleaseType[] = currentVersionIsPrerelease ? ['patch', 'prepatch'] : ['patch']
+  const prereleaseTypes: ReleaseType[] = ['prerelease']
+
+  const majorUpgrade = pickHighest(eligibleUpgrades, majorTypes)
+  const minorUpgrade = pickHighest(eligibleUpgrades, minorTypes)
+  const patchUpgrade = pickHighest(eligibleUpgrades, patchTypes)
+  const prereleaseUpgrade = currentVersionIsPrerelease
+    ? pickHighest(eligibleUpgrades, prereleaseTypes)
+    : undefined
+
+  // Only compute per-bucket "latest" when the age filter could have held something back.
+  const ageFilterActive = eligibleUpgrades !== possibleUpgrades
+  const heldBack = (eligible: VersionData | undefined, trueLatest: VersionData | undefined) =>
+    trueLatest !== undefined && (eligible === undefined || gt(trueLatest.version, eligible.version))
+      ? trueLatest
+      : undefined
+
+  const majorLatest = ageFilterActive
+    ? heldBack(majorUpgrade, pickHighest(possibleUpgrades, majorTypes))
+    : undefined
+  const minorLatest = ageFilterActive
+    ? heldBack(minorUpgrade, pickHighest(possibleUpgrades, minorTypes))
+    : undefined
+  const patchLatest = ageFilterActive
+    ? heldBack(patchUpgrade, pickHighest(possibleUpgrades, patchTypes))
+    : undefined
+  const prereleaseLatest =
+    ageFilterActive && currentVersionIsPrerelease
+      ? heldBack(prereleaseUpgrade, pickHighest(possibleUpgrades, prereleaseTypes))
+      : undefined
+
   return {
     major: majorUpgrade,
     minor: minorUpgrade,
     patch: patchUpgrade,
     prerelease: prereleaseUpgrade,
+    ...(majorLatest !== undefined ? { majorLatest } : {}),
+    ...(minorLatest !== undefined ? { minorLatest } : {}),
+    ...(patchLatest !== undefined ? { patchLatest } : {}),
+    ...(prereleaseLatest !== undefined ? { prereleaseLatest } : {}),
     validVersion: true,
     existingVersion,
   }
+}
+
+const filterByReleaseAge = (
+  upgrades: VersionData[],
+  npmData: NpmData,
+  dependencyName: string,
+  ageFilter: ReleaseAgeFilter | undefined,
+): VersionData[] => {
+  if (ageFilter === undefined || ageFilter.minimumReleaseAgeMinutes <= 0) {
+    return upgrades
+  }
+  if (ageFilter.excludedPackages.includes(dependencyName)) {
+    return upgrades
+  }
+  const now = ageFilter.now ?? Date.now()
+  const minAgeMs = ageFilter.minimumReleaseAgeMinutes * 60 * 1000
+  const timeMap = npmData.time
+  return upgrades.filter((version) => {
+    const publishedAt = timeMap?.[version.version]
+    if (publishedAt === undefined) {
+      // Missing publish metadata — be permissive rather than hiding the upgrade.
+      return true
+    }
+    const publishedMs = new Date(publishedAt).getTime()
+    if (Number.isNaN(publishedMs)) {
+      return true
+    }
+    return now - publishedMs >= minAgeMs
+  })
 }
 
 const getRawPossibleUpgradeList = (

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -43,6 +43,10 @@ export interface NpmData {
         directory?: string
       }
     | string
+  // ISO-8601 publish timestamps keyed by version (plus 'created' / 'modified' entries).
+  time?: {
+    [key in string]: string
+  }
 }
 
 export interface VersionData {
@@ -55,6 +59,11 @@ export interface DependencyUpdateInfo {
   minor?: VersionData
   patch?: VersionData
   prerelease?: VersionData
+  // Per-bucket "true latest" — only set when higher than the eligible upgrade, i.e. held back by minimumReleaseAge.
+  majorLatest?: VersionData
+  minorLatest?: VersionData
+  patchLatest?: VersionData
+  prereleaseLatest?: VersionData
   validVersion: boolean // if the current version is valid semver
   existingVersion: boolean // if the current version exists
 }
@@ -82,17 +91,28 @@ export const setCachedNpmData = (newNpmCache: Dict<string, NpmLoader<CacheItem>>
   npmCache = newNpmCache
 }
 
+export interface ReleaseAgeFilter {
+  minimumReleaseAgeMinutes: number
+  excludedPackages: string[]
+  now?: number // override for tests; defaults to Date.now()
+}
+
 export const getLatestVersion = (
   npmData: NpmData,
   rawCurrentVersion: string,
   dependencyName: string,
 ): VersionData | undefined => {
-  const ignoredVersions = getConfig().ignoreVersions[dependencyName]
+  const config = getConfig()
+  const ignoredVersions = config.ignoreVersions[dependencyName]
   return getLatestVersionWithIgnoredVersions(
     npmData,
     rawCurrentVersion,
     dependencyName,
     ignoredVersions,
+    {
+      minimumReleaseAgeMinutes: config.minimumReleaseAge,
+      excludedPackages: config.minimumReleaseAgeExclude,
+    },
   )
 }
 
@@ -101,12 +121,14 @@ export const getLatestVersionWithIgnoredVersions = (
   rawCurrentVersion: string,
   dependencyName: string,
   ignoredVersions: string | undefined | string[],
+  ageFilter?: ReleaseAgeFilter,
 ): VersionData | undefined => {
   const possibleUpgrades = getPossibleUpgradesWithIgnoredVersions(
     npmData,
     rawCurrentVersion,
     dependencyName,
     ignoredVersions,
+    ageFilter,
   )
   return (
     possibleUpgrades.major ??
@@ -141,12 +163,17 @@ export const getPossibleUpgrades = (
   rawCurrentVersion: string,
   dependencyName: string,
 ): DependencyUpdateInfo => {
-  const ignoredVersions = getConfig().ignoreVersions[dependencyName]
+  const config = getConfig()
+  const ignoredVersions = config.ignoreVersions[dependencyName]
   return getPossibleUpgradesWithIgnoredVersions(
     npmData,
     rawCurrentVersion,
     dependencyName,
     ignoredVersions,
+    {
+      minimumReleaseAgeMinutes: config.minimumReleaseAge,
+      excludedPackages: config.minimumReleaseAgeExclude,
+    },
   )
 }
 
@@ -155,6 +182,7 @@ export const getPossibleUpgradesWithIgnoredVersions = (
   rawCurrentVersion: string,
   dependencyName: string,
   ignoredVersions: string | undefined | string[],
+  ageFilter?: ReleaseAgeFilter,
 ): DependencyUpdateInfo => {
   if (rawCurrentVersion === '*' || rawCurrentVersion === 'x') {
     return { validVersion: true, existingVersion: true }
@@ -192,8 +220,10 @@ export const getPossibleUpgradesWithIgnoredVersions = (
     coercedVersion,
   )
 
-  const helper = (releaseTypeList: ReleaseType[]) => {
-    const matchingUpgradeTypes = possibleUpgrades.filter((version) => {
+  const eligibleUpgrades = filterByReleaseAge(possibleUpgrades, npmData, dependencyName, ageFilter)
+
+  const pickHighest = (source: VersionData[], releaseTypeList: ReleaseType[]) => {
+    const matchingUpgradeTypes = source.filter((version) => {
       const diffType = diff(version.version, coercedVersion)
       return diffType !== null && releaseTypeList.includes(diffType)
     })
@@ -204,18 +234,80 @@ export const getPossibleUpgradesWithIgnoredVersions = (
 
   // If we are at a prerelease, then show all pre-x.
   // This is partially done to account for when there are only pre-x versions.
-  const majorUpgrade = helper(currentVersionIsPrerelease ? ['major', 'premajor'] : ['major'])
-  const minorUpgrade = helper(currentVersionIsPrerelease ? ['minor', 'preminor'] : ['minor'])
-  const patchUpgrade = helper(currentVersionIsPrerelease ? ['patch', 'prepatch'] : ['patch'])
-  const prereleaseUpgrade = currentVersionIsPrerelease ? helper(['prerelease']) : undefined
+  const majorTypes: ReleaseType[] = currentVersionIsPrerelease ? ['major', 'premajor'] : ['major']
+  const minorTypes: ReleaseType[] = currentVersionIsPrerelease ? ['minor', 'preminor'] : ['minor']
+  const patchTypes: ReleaseType[] = currentVersionIsPrerelease ? ['patch', 'prepatch'] : ['patch']
+  const prereleaseTypes: ReleaseType[] = ['prerelease']
+
+  const majorUpgrade = pickHighest(eligibleUpgrades, majorTypes)
+  const minorUpgrade = pickHighest(eligibleUpgrades, minorTypes)
+  const patchUpgrade = pickHighest(eligibleUpgrades, patchTypes)
+  const prereleaseUpgrade = currentVersionIsPrerelease
+    ? pickHighest(eligibleUpgrades, prereleaseTypes)
+    : undefined
+
+  // Only compute per-bucket "latest" when the age filter could have held something back.
+  const ageFilterActive = eligibleUpgrades !== possibleUpgrades
+  const heldBack = (eligible: VersionData | undefined, trueLatest: VersionData | undefined) =>
+    trueLatest !== undefined && (eligible === undefined || gt(trueLatest.version, eligible.version))
+      ? trueLatest
+      : undefined
+
+  const majorLatest = ageFilterActive
+    ? heldBack(majorUpgrade, pickHighest(possibleUpgrades, majorTypes))
+    : undefined
+  const minorLatest = ageFilterActive
+    ? heldBack(minorUpgrade, pickHighest(possibleUpgrades, minorTypes))
+    : undefined
+  const patchLatest = ageFilterActive
+    ? heldBack(patchUpgrade, pickHighest(possibleUpgrades, patchTypes))
+    : undefined
+  const prereleaseLatest =
+    ageFilterActive && currentVersionIsPrerelease
+      ? heldBack(prereleaseUpgrade, pickHighest(possibleUpgrades, prereleaseTypes))
+      : undefined
+
   return {
     major: majorUpgrade,
     minor: minorUpgrade,
     patch: patchUpgrade,
     prerelease: prereleaseUpgrade,
+    ...(majorLatest !== undefined ? { majorLatest } : {}),
+    ...(minorLatest !== undefined ? { minorLatest } : {}),
+    ...(patchLatest !== undefined ? { patchLatest } : {}),
+    ...(prereleaseLatest !== undefined ? { prereleaseLatest } : {}),
     validVersion: true,
     existingVersion,
   }
+}
+
+const filterByReleaseAge = (
+  upgrades: VersionData[],
+  npmData: NpmData,
+  dependencyName: string,
+  ageFilter: ReleaseAgeFilter | undefined,
+): VersionData[] => {
+  if (ageFilter === undefined || ageFilter.minimumReleaseAgeMinutes <= 0) {
+    return upgrades
+  }
+  if (ageFilter.excludedPackages.includes(dependencyName)) {
+    return upgrades
+  }
+  const now = ageFilter.now ?? Date.now()
+  const minAgeMs = ageFilter.minimumReleaseAgeMinutes * 60 * 1000
+  const timeMap = npmData.time
+  return upgrades.filter((version) => {
+    const publishedAt = timeMap?.[version.version]
+    if (publishedAt === undefined) {
+      // Missing publish metadata — be permissive rather than hiding the upgrade.
+      return true
+    }
+    const publishedMs = new Date(publishedAt).getTime()
+    if (Number.isNaN(publishedMs)) {
+      return true
+    }
+    return now - publishedMs >= minAgeMs
+  })
 }
 
 const getRawPossibleUpgradeList = (

--- a/src/test-node/npm.test.ts
+++ b/src/test-node/npm.test.ts
@@ -79,6 +79,8 @@ describe('Npm Test Suite', () => {
       ignoreVersions: {},
       msUntilRowLoading: 6000,
       dependencyGroups: ['dependencies', 'devDependencies'],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: [],
     }
     setConfig(config)
   })
@@ -413,5 +415,187 @@ describe('Npm Test Suite', () => {
       existingVersion: true,
     }
     assert.deepStrictEqual(result, expected)
+  })
+
+  // Age filter fixtures: "NOW" is 2026-04-23T12:00:00Z; versions are dated relative to that.
+  const NOW = new Date('2026-04-23T12:00:00Z').getTime()
+  const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString()
+  const MINUTES = 60 * 1000
+  const DAYS = 24 * 60 * MINUTES
+
+  const ageTestData: NpmData = {
+    'dist-tags': { latest: '2.1.1' },
+    versions: {
+      '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+      '2.1.0': { name: 'dependencyName', version: '2.1.0' },
+      '2.1.1': { name: 'dependencyName', version: '2.1.1' },
+    },
+    time: {
+      '2.0.0': iso(60 * DAYS),
+      '2.1.0': iso(30 * DAYS),
+      '2.1.1': iso(1 * DAYS), // published 1 day ago — younger than 7-day threshold
+    },
+  }
+
+  test('minimumReleaseAge holds back the freshest patch and surfaces the eligible one', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.0' })
+    assert.deepStrictEqual(result.minorLatest, { name: 'dependencyName', version: '2.1.1' })
+    // No patch bucket since current is 2.0.0 (2.1.x is a minor bump).
+    assert.strictEqual(result.patch, undefined)
+    assert.strictEqual(result.patchLatest, undefined)
+  })
+
+  test('minimumReleaseAge older than any version leaves eligible = latest and no held-back fields', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 1, // 1 minute — every published version passes
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('minimumReleaseAgeExclude bypasses the age filter for a package', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: ['dependencyName'],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('minimumReleaseAge of 0 disables the filter', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 0,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('versions with missing publish time pass through the age filter', () => {
+    const partialTimeData: NpmData = {
+      'dist-tags': { latest: '2.1.1' },
+      versions: {
+        '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+        '2.1.1': { name: 'dependencyName', version: '2.1.1' },
+      },
+      time: {
+        '2.0.0': iso(60 * DAYS),
+        // 2.1.1 has no publish time — should not be hidden.
+      },
+    }
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      partialTimeData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('minimumReleaseAge held-back surfaces across major/minor/patch buckets independently', () => {
+    const multiBucket: NpmData = {
+      'dist-tags': { latest: '3.0.0' },
+      versions: {
+        '1.0.0': { name: 'dependencyName', version: '1.0.0' },
+        '1.0.1': { name: 'dependencyName', version: '1.0.1' },
+        '1.0.2': { name: 'dependencyName', version: '1.0.2' },
+        '1.1.0': { name: 'dependencyName', version: '1.1.0' },
+        '1.1.1': { name: 'dependencyName', version: '1.1.1' },
+        '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+        '3.0.0': { name: 'dependencyName', version: '3.0.0' },
+      },
+      time: {
+        '1.0.0': iso(60 * DAYS),
+        '1.0.1': iso(30 * DAYS),
+        '1.0.2': iso(1 * DAYS), // held back
+        '1.1.0': iso(30 * DAYS),
+        '1.1.1': iso(2 * DAYS), // held back
+        '2.0.0': iso(30 * DAYS),
+        '3.0.0': iso(3 * DAYS), // held back
+      },
+    }
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      multiBucket,
+      '1.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.major, { name: 'dependencyName', version: '2.0.0' })
+    assert.deepStrictEqual(result.majorLatest, { name: 'dependencyName', version: '3.0.0' })
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '1.1.0' })
+    assert.deepStrictEqual(result.minorLatest, { name: 'dependencyName', version: '1.1.1' })
+    assert.deepStrictEqual(result.patch, { name: 'dependencyName', version: '1.0.1' })
+    assert.deepStrictEqual(result.patchLatest, { name: 'dependencyName', version: '1.0.2' })
+  })
+
+  test('minimumReleaseAge that filters out the whole bucket leaves eligible undefined but latest populated', () => {
+    const allFresh: NpmData = {
+      'dist-tags': { latest: '2.0.1' },
+      versions: {
+        '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+        '2.0.1': { name: 'dependencyName', version: '2.0.1' },
+      },
+      time: {
+        '2.0.0': iso(2 * DAYS), // all patches are younger than threshold
+        '2.0.1': iso(1 * DAYS),
+      },
+    }
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      allFresh,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.strictEqual(result.patch, undefined)
+    assert.deepStrictEqual(result.patchLatest, { name: 'dependencyName', version: '2.0.1' })
   })
 })

--- a/src/test-node/npm.test.ts
+++ b/src/test-node/npm.test.ts
@@ -80,6 +80,8 @@ describe('Npm Test Suite', () => {
       ignoreVersions: {},
       msUntilRowLoading: 6000,
       dependencyGroups: ['dependencies', 'devDependencies'],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: [],
     }
     setConfig(config)
   })
@@ -445,6 +447,188 @@ describe('Npm Test Suite', () => {
       existingVersion: true,
     }
     assert.deepStrictEqual(result, expected)
+  })
+
+  // Age filter fixtures: "NOW" is 2026-04-23T12:00:00Z; versions are dated relative to that.
+  const NOW = new Date('2026-04-23T12:00:00Z').getTime()
+  const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString()
+  const MINUTES = 60 * 1000
+  const DAYS = 24 * 60 * MINUTES
+
+  const ageTestData: NpmData = {
+    'dist-tags': { latest: '2.1.1' },
+    versions: {
+      '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+      '2.1.0': { name: 'dependencyName', version: '2.1.0' },
+      '2.1.1': { name: 'dependencyName', version: '2.1.1' },
+    },
+    time: {
+      '2.0.0': iso(60 * DAYS),
+      '2.1.0': iso(30 * DAYS),
+      '2.1.1': iso(1 * DAYS), // published 1 day ago — younger than 7-day threshold
+    },
+  }
+
+  test('minimumReleaseAge holds back the freshest patch and surfaces the eligible one', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.0' })
+    assert.deepStrictEqual(result.minorLatest, { name: 'dependencyName', version: '2.1.1' })
+    // No patch bucket since current is 2.0.0 (2.1.x is a minor bump).
+    assert.strictEqual(result.patch, undefined)
+    assert.strictEqual(result.patchLatest, undefined)
+  })
+
+  test('minimumReleaseAge older than any version leaves eligible = latest and no held-back fields', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 1, // 1 minute — every published version passes
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('minimumReleaseAgeExclude bypasses the age filter for a package', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: ['dependencyName'],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('minimumReleaseAge of 0 disables the filter', () => {
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      ageTestData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 0,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('versions with missing publish time pass through the age filter', () => {
+    const partialTimeData: NpmData = {
+      'dist-tags': { latest: '2.1.1' },
+      versions: {
+        '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+        '2.1.1': { name: 'dependencyName', version: '2.1.1' },
+      },
+      time: {
+        '2.0.0': iso(60 * DAYS),
+        // 2.1.1 has no publish time — should not be hidden.
+      },
+    }
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      partialTimeData,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '2.1.1' })
+    assert.strictEqual(result.minorLatest, undefined)
+  })
+
+  test('minimumReleaseAge held-back surfaces across major/minor/patch buckets independently', () => {
+    const multiBucket: NpmData = {
+      'dist-tags': { latest: '3.0.0' },
+      versions: {
+        '1.0.0': { name: 'dependencyName', version: '1.0.0' },
+        '1.0.1': { name: 'dependencyName', version: '1.0.1' },
+        '1.0.2': { name: 'dependencyName', version: '1.0.2' },
+        '1.1.0': { name: 'dependencyName', version: '1.1.0' },
+        '1.1.1': { name: 'dependencyName', version: '1.1.1' },
+        '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+        '3.0.0': { name: 'dependencyName', version: '3.0.0' },
+      },
+      time: {
+        '1.0.0': iso(60 * DAYS),
+        '1.0.1': iso(30 * DAYS),
+        '1.0.2': iso(1 * DAYS), // held back
+        '1.1.0': iso(30 * DAYS),
+        '1.1.1': iso(2 * DAYS), // held back
+        '2.0.0': iso(30 * DAYS),
+        '3.0.0': iso(3 * DAYS), // held back
+      },
+    }
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      multiBucket,
+      '1.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.deepStrictEqual(result.major, { name: 'dependencyName', version: '2.0.0' })
+    assert.deepStrictEqual(result.majorLatest, { name: 'dependencyName', version: '3.0.0' })
+    assert.deepStrictEqual(result.minor, { name: 'dependencyName', version: '1.1.0' })
+    assert.deepStrictEqual(result.minorLatest, { name: 'dependencyName', version: '1.1.1' })
+    assert.deepStrictEqual(result.patch, { name: 'dependencyName', version: '1.0.1' })
+    assert.deepStrictEqual(result.patchLatest, { name: 'dependencyName', version: '1.0.2' })
+  })
+
+  test('minimumReleaseAge that filters out the whole bucket leaves eligible undefined but latest populated', () => {
+    const allFresh: NpmData = {
+      'dist-tags': { latest: '2.0.1' },
+      versions: {
+        '2.0.0': { name: 'dependencyName', version: '2.0.0' },
+        '2.0.1': { name: 'dependencyName', version: '2.0.1' },
+      },
+      time: {
+        '2.0.0': iso(2 * DAYS), // all patches are younger than threshold
+        '2.0.1': iso(1 * DAYS),
+      },
+    }
+    const result = getPossibleUpgradesWithIgnoredVersions(
+      allFresh,
+      '2.0.0',
+      'dependencyName',
+      undefined,
+      {
+        minimumReleaseAgeMinutes: 7 * 24 * 60,
+        excludedPackages: [],
+        now: NOW,
+      },
+    )
+    assert.strictEqual(result.patch, undefined)
+    assert.deepStrictEqual(result.patchLatest, { name: 'dependencyName', version: '2.0.1' })
   })
 })
 

--- a/src/test-node/npmConfig.test.ts
+++ b/src/test-node/npmConfig.test.ts
@@ -23,6 +23,8 @@ describe('npmConfig', () => {
       ignoreVersions: {},
       msUntilRowLoading: 6000,
       dependencyGroups: ['dependencies', 'devDependencies'],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: [],
     }
     setConfig(config)
   })

--- a/src/test-node/packageJson.test.ts
+++ b/src/test-node/packageJson.test.ts
@@ -21,6 +21,8 @@ describe('packageJson', () => {
       ignoreVersions: {},
       msUntilRowLoading: 6000,
       dependencyGroups: ['dependencies', 'devDependencies'],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: [],
     }
     setConfig(config)
   })

--- a/src/test-node/packageJson.test.ts
+++ b/src/test-node/packageJson.test.ts
@@ -23,6 +23,8 @@ describe('packageJson', () => {
       ignoreVersions: {},
       msUntilRowLoading: 6000,
       dependencyGroups: ['dependencies', 'devDependencies'],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: [],
     }
     setConfig(config)
   })

--- a/src/test-vscode/updateAll.test.ts
+++ b/src/test-vscode/updateAll.test.ts
@@ -75,6 +75,8 @@ suite('UpdateAll Test Suite', () => {
       ignoreVersions: {},
       msUntilRowLoading: 6000,
       dependencyGroups: ['dependencies', 'devDependencies'],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: [],
     }
     setConfig(config)
 

--- a/src/test-vscode/updateAll.test.ts
+++ b/src/test-vscode/updateAll.test.ts
@@ -76,6 +76,8 @@ suite('UpdateAll Test Suite', () => {
       ignoreVersions: {},
       msUntilRowLoading: 6000,
       dependencyGroups: ['dependencies', 'devDependencies'],
+      minimumReleaseAge: 0,
+      minimumReleaseAgeExclude: [],
     }
     setConfig(config)
 

--- a/src/texteditor.ts
+++ b/src/texteditor.ts
@@ -177,18 +177,31 @@ const paintDecorations = (
     let text: string | undefined
     if (possibleUpgrades.major !== undefined) {
       // TODO add info about patch version?
-      text = getUpdateDescription(possibleUpgrades.major.version, possibleUpgrades.existingVersion)
+      text = getUpdateDescription(
+        possibleUpgrades.major.version,
+        possibleUpgrades.existingVersion,
+        possibleUpgrades.majorLatest?.version,
+      )
       decorator = getDecoratorForUpdate('major', text)
     } else if (possibleUpgrades.minor !== undefined) {
-      text = getUpdateDescription(possibleUpgrades.minor.version, possibleUpgrades.existingVersion)
+      text = getUpdateDescription(
+        possibleUpgrades.minor.version,
+        possibleUpgrades.existingVersion,
+        possibleUpgrades.minorLatest?.version,
+      )
       decorator = getDecoratorForUpdate('minor', text)
     } else if (possibleUpgrades.patch !== undefined) {
-      text = getUpdateDescription(possibleUpgrades.patch.version, possibleUpgrades.existingVersion)
+      text = getUpdateDescription(
+        possibleUpgrades.patch.version,
+        possibleUpgrades.existingVersion,
+        possibleUpgrades.patchLatest?.version,
+      )
       decorator = getDecoratorForUpdate('patch', text)
     } else if (possibleUpgrades.prerelease !== undefined) {
       text = getUpdateDescription(
         possibleUpgrades.prerelease.version,
         possibleUpgrades.existingVersion,
+        possibleUpgrades.prereleaseLatest?.version,
       )
       decorator = getDecoratorForUpdate('prerelease', text)
     } else if (possibleUpgrades.validVersion === false) {


### PR DESCRIPTION
- closes: #61 

This adds a support for minimum release age as a config (instead of reading directly from any of the package manager configs).

Adds two configs:
- `"minimumReleaseAge"`: Mirrors npm's minimumReleaseAge. Hide upgrades to versions published less than this many minutes ago. When the newest version is held back, the decoration shows the highest eligible upgrade and the true latest (e.g. `5.1.0 (latest 5.2.0)`).
- `"minimumReleaseAgeExclude"`: Package names to exclude from the minimumReleaseAge check.

Example of how it looks:

<img width="443" height="321" alt="image" src="https://github.com/user-attachments/assets/d694382b-7f75-43ad-bf0b-053c5a2d05b8" />
