### PR TITLE
feat: show upgrade decorations in pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "activationEvents": [
     "onLanguage:json",
-    "onLanguage:jsonc"
+    "onLanguage:jsonc",
+    "onLanguage:yaml"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,10 +115,16 @@ const checkCurrentFiles = (showDecorations: boolean) => {
 }
 
 const activateCodeActionStuff = (context: vscode.ExtensionContext) => {
+  const updateAction = new UpdateAction()
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider({ pattern: '**/package.json' }, updateAction, {
+      providedCodeActionKinds: UpdateAction.providedCodeActionKinds,
+    }),
+  )
   context.subscriptions.push(
     vscode.languages.registerCodeActionsProvider(
-      { pattern: '**/package.json' },
-      new UpdateAction(),
+      [{ pattern: '**/pnpm-workspace.yaml' }, { pattern: '**/pnpm-workspace.yml' }],
+      updateAction,
       {
         providedCodeActionKinds: UpdateAction.providedCodeActionKinds,
       },

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,3 +1,4 @@
+import * as yaml from 'js-yaml'
 import * as npmRegistryFetch from 'npm-registry-fetch'
 import {
   coerce,
@@ -17,7 +18,7 @@ import { getConfig } from './config'
 import { logError } from './log'
 import { getNpmConfig } from './npmConfig'
 import { AsyncState, Dict, StrictDict } from './types'
-import { resolveCatalogVersion, resolveWorkspaceVersion } from './workspace'
+import { isRecord, resolveCatalogVersion, resolveWorkspaceVersion } from './workspace'
 
 export interface NpmLoader<T> {
   asyncstate: AsyncState
@@ -254,6 +255,68 @@ const isVersionIgnored = (version: VersionData, dependencyName: string, ignoredV
     return true
   }
   return satisfies(version.version, ignoredVersion)
+}
+
+export const refreshWorkspaceFileData = (
+  content: string,
+  workspaceFilePath: string,
+): Promise<void>[] => {
+  const cacheCutoff = new Date(new Date().getTime() - 1000 * 60 * 120)
+
+  try {
+    const parsed = yaml.load(content)
+    if (!isRecord(parsed)) {
+      return []
+    }
+
+    const dependencies: Record<string, string> = {}
+
+    if (isRecord(parsed.catalog)) {
+      for (const [name, version] of Object.entries(parsed.catalog)) {
+        if (typeof version === 'string') {
+          dependencies[name] = version
+        }
+      }
+    }
+
+    if (isRecord(parsed.catalogs)) {
+      for (const entries of Object.values(parsed.catalogs)) {
+        if (isRecord(entries)) {
+          for (const [name, version] of Object.entries(entries)) {
+            if (typeof version === 'string') {
+              dependencies[name] = version
+            }
+          }
+        }
+      }
+    }
+
+    const promises = Object.entries(dependencies)
+      .filter(([_dependencyName, version]) => {
+        if (valid(coerce(version)) == null) {
+          return false
+        }
+        return true
+      })
+      .map(([dependencyName, _version]) => {
+        const cache = npmCache[dependencyName]
+        if (
+          cache === undefined ||
+          cache.asyncstate === AsyncState.NotStarted ||
+          (cache.item !== undefined && cache.item.date.getTime() < cacheCutoff.getTime())
+        ) {
+          return fetchNpmData(dependencyName, workspaceFilePath)
+        } else {
+          return npmCache[dependencyName]?.promise
+        }
+      })
+      .filter((p): p is Promise<void> => p !== undefined)
+
+    return promises
+  } catch (_) {
+    console.warn(`Failed to parse pnpm-workspace file: ${workspaceFilePath}`)
+    return [Promise.resolve()]
+  }
 }
 
 export const refreshPackageJsonData = (

--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -17,6 +17,15 @@ export interface Dependency {
   isCatalog?: boolean
 }
 
+export const isPnpmWorkspaceFile = (document: vscode.TextDocument) => {
+  return (
+    document.fileName.endsWith('/pnpm-workspace.yaml') ||
+    document.fileName.endsWith('\\pnpm-workspace.yaml') ||
+    document.fileName.endsWith('/pnpm-workspace.yml') ||
+    document.fileName.endsWith('\\pnpm-workspace.yml')
+  )
+}
+
 export const getDependencyFromLine = (
   jsonAsString: string,
   line: number,

--- a/src/test-node/workspace.test.ts
+++ b/src/test-node/workspace.test.ts
@@ -3,7 +3,12 @@ import { before, describe, test } from 'node:test'
 import * as assert from 'assert'
 import * as path from 'path'
 
-import { clearWorkspaceCache, resolveCatalogVersion, resolveWorkspaceVersion } from '../workspace'
+import {
+  clearWorkspaceCache,
+  getWorkspaceFileDependencyInformation,
+  resolveCatalogVersion,
+  resolveWorkspaceVersion,
+} from '../workspace'
 
 const testdataDir = path.resolve('./src/test-node/testdata')
 const catalogWorkspaceDir = path.resolve('./src/test-node/testdata/catalog-workspace')
@@ -222,5 +227,154 @@ describe('workspace', () => {
       path.join(testdataDir, 'ws-invalid', 'packages', 'consumer', 'package.json'),
     )
     assert.strictEqual(catalogResult, undefined)
+  })
+
+  test('should extract catalog dependencies from workspace file', () => {
+    const groups = getWorkspaceFileDependencyInformation(`packages:
+  - 'packages/*'
+catalog:
+  react: ^18.0.0
+  lodash: ^4.17.0
+`)
+
+    assert.strictEqual(groups.length, 1)
+    assert.strictEqual(groups[0].startLine, 2)
+    assert.strictEqual(groups[0].deps.length, 2)
+
+    const react = groups[0].deps.find((d) => d.dependencyName === 'react')
+    assert.ok(react)
+    assert.strictEqual(react.currentVersion, '^18.0.0')
+    assert.strictEqual(react.line, 3)
+
+    const lodash = groups[0].deps.find((d) => d.dependencyName === 'lodash')
+    assert.ok(lodash)
+    assert.strictEqual(lodash.currentVersion, '^4.17.0')
+    assert.strictEqual(lodash.line, 4)
+  })
+
+  test('should extract named catalog dependencies from workspace file', () => {
+    const groups = getWorkspaceFileDependencyInformation(`catalogs:
+  legacy:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+`)
+
+    assert.strictEqual(groups.length, 1)
+    assert.strictEqual(groups[0].startLine, 1)
+    assert.strictEqual(groups[0].deps.length, 2)
+
+    const react = groups[0].deps.find((d) => d.dependencyName === 'react')
+    assert.ok(react)
+    assert.strictEqual(react.currentVersion, '^17.0.2')
+    assert.strictEqual(react.line, 2)
+
+    const reactDom = groups[0].deps.find((d) => d.dependencyName === 'react-dom')
+    assert.ok(reactDom)
+    assert.strictEqual(reactDom.currentVersion, '^17.0.2')
+    assert.strictEqual(reactDom.line, 3)
+  })
+
+  test('should extract both catalog and named catalogs', () => {
+    const groups = getWorkspaceFileDependencyInformation(`catalog:
+  react: ^18.0.0
+catalogs:
+  legacy:
+    react: ^17.0.2
+`)
+
+    assert.strictEqual(groups.length, 2)
+
+    const catalogGroup = groups.find((g) => g.startLine === 0)
+    assert.ok(catalogGroup)
+    assert.strictEqual(catalogGroup.deps.length, 1)
+    assert.strictEqual(catalogGroup.deps[0].dependencyName, 'react')
+    assert.strictEqual(catalogGroup.deps[0].currentVersion, '^18.0.0')
+
+    const legacyGroup = groups.find((g) => g.startLine === 3)
+    assert.ok(legacyGroup)
+    assert.strictEqual(legacyGroup.deps.length, 1)
+    assert.strictEqual(legacyGroup.deps[0].dependencyName, 'react')
+    assert.strictEqual(legacyGroup.deps[0].currentVersion, '^17.0.2')
+  })
+
+  test('should handle workspace file with comments and mixed quotes', () => {
+    const groups = getWorkspaceFileDependencyInformation(`packages:
+  - 'packages/*'
+# main deps
+catalog:
+  react: ^18.0.0
+  "lodash": '^4.17.0'
+`)
+
+    assert.strictEqual(groups.length, 1)
+    assert.strictEqual(groups[0].deps.length, 2)
+
+    const react = groups[0].deps.find((d) => d.dependencyName === 'react')
+    assert.ok(react)
+    assert.strictEqual(react.line, 4)
+
+    const lodash = groups[0].deps.find((d) => d.dependencyName === 'lodash')
+    assert.ok(lodash)
+    assert.strictEqual(lodash.line, 5)
+  })
+
+  test('should return empty for invalid yaml', () => {
+    const groups = getWorkspaceFileDependencyInformation('this is not { valid yaml ::::')
+    assert.strictEqual(groups.length, 0)
+  })
+
+  test('should return empty for workspace file without catalogs', () => {
+    const groups = getWorkspaceFileDependencyInformation(`packages:
+  - 'packages/*'
+`)
+    assert.strictEqual(groups.length, 0)
+  })
+
+  test('should not confuse catalog name with dependency name in another section', () => {
+    const groups = getWorkspaceFileDependencyInformation(`catalog:
+  legacy: ^1.0.0
+catalogs:
+  legacy:
+    react: ^18.0.0
+`)
+
+    assert.strictEqual(groups.length, 2)
+
+    const catalogGroup = groups.find((g) => g.startLine === 0)
+    assert.ok(catalogGroup)
+    assert.strictEqual(catalogGroup.deps.length, 1)
+    assert.strictEqual(catalogGroup.deps[0].dependencyName, 'legacy')
+    assert.strictEqual(catalogGroup.deps[0].currentVersion, '^1.0.0')
+
+    const legacyGroup = groups.find((g) => g.startLine === 3)
+    assert.ok(legacyGroup)
+    assert.strictEqual(legacyGroup.deps.length, 1)
+    assert.strictEqual(legacyGroup.deps[0].dependencyName, 'react')
+    assert.strictEqual(legacyGroup.deps[0].currentVersion, '^18.0.0')
+  })
+
+  test('should deduplicate lines when same dependency appears in catalog and catalogs with same version', () => {
+    const groups = getWorkspaceFileDependencyInformation(`catalog:
+  react: ^18.0.0
+catalogs:
+  legacy:
+    react: ^18.0.0
+`)
+
+    assert.strictEqual(groups.length, 2)
+
+    const catalogGroup = groups.find((g) => g.startLine === 0)
+    assert.ok(catalogGroup)
+    assert.strictEqual(catalogGroup.deps.length, 1)
+    assert.strictEqual(catalogGroup.deps[0].dependencyName, 'react')
+    assert.strictEqual(catalogGroup.deps[0].currentVersion, '^18.0.0')
+    assert.strictEqual(catalogGroup.deps[0].line, 1)
+
+    const legacyGroup = groups.find((g) => g.startLine === 3)
+    assert.ok(legacyGroup)
+    assert.strictEqual(legacyGroup.deps.length, 1)
+    assert.strictEqual(legacyGroup.deps[0].dependencyName, 'react')
+    assert.strictEqual(legacyGroup.deps[0].currentVersion, '^18.0.0')
+    assert.strictEqual(legacyGroup.deps[0].line, 4)
   })
 })

--- a/src/texteditor.ts
+++ b/src/texteditor.ts
@@ -4,9 +4,20 @@ import { TextEditorDecorationType } from 'vscode'
 import { getConfig } from './config'
 import { decorateDiscreet, getDecoratorForUpdate, getUpdateDescription } from './decorations'
 import { getIgnorePattern, isDependencyIgnored } from './ignorePattern'
-import { getCachedNpmData, getPossibleUpgrades, refreshPackageJsonData } from './npm'
-import { DependencyGroups, getDependencyInformation, isPackageJson } from './packageJson'
+import {
+  getCachedNpmData,
+  getPossibleUpgrades,
+  refreshPackageJsonData,
+  refreshWorkspaceFileData,
+} from './npm'
+import {
+  DependencyGroups,
+  getDependencyInformation,
+  isPackageJson,
+  isPnpmWorkspaceFile,
+} from './packageJson'
 import { AsyncState } from './types'
+import { getWorkspaceFileDependencyInformation } from './workspace'
 
 interface DecorationWrapper {
   line: number
@@ -30,7 +41,7 @@ export const handleFileDecoration = (document: vscode.TextDocument) => {
     return
   }
 
-  if (!isPackageJson(document)) {
+  if (!isPackageJson(document) && !isPnpmWorkspaceFile(document)) {
     return
   }
 
@@ -42,14 +53,19 @@ export const handleFileDecoration = (document: vscode.TextDocument) => {
 
 const loadDecoration = async (document: vscode.TextDocument, startTime: number) => {
   const text = document.getText()
-  const dependencyGroups = getDependencyInformation(text, document.uri.fsPath)
+  const isWorkspaceFile = isPnpmWorkspaceFile(document)
+  const dependencyGroups = isWorkspaceFile
+    ? getWorkspaceFileDependencyInformation(text)
+    : getDependencyInformation(text, document.uri.fsPath)
 
   const textEditor = getTextEditorFromDocument(document)
   if (textEditor === undefined) {
     return
   }
 
-  const promises = refreshPackageJsonData(document.getText(), document.uri.fsPath)
+  const promises = isWorkspaceFile
+    ? refreshWorkspaceFileData(document.getText(), document.uri.fsPath)
+    : refreshPackageJsonData(document.getText(), document.uri.fsPath)
 
   try {
     await Promise.race([...promises, Promise.resolve()])

--- a/src/updateAction.ts
+++ b/src/updateAction.ts
@@ -3,8 +3,9 @@ import * as vscode from 'vscode'
 import { getChangelogUrl } from './changelog'
 import { OPEN_URL_COMMAND } from './extension'
 import { getCachedNpmData, getExactVersion, getPossibleUpgrades } from './npm'
-import { getDependencyFromLine, isPackageJson } from './packageJson'
+import { getDependencyFromLine, isPackageJson, isPnpmWorkspaceFile } from './packageJson'
 import { replaceLastOccuranceOf } from './util/util'
+import { getWorkspaceDependencyFromLine } from './workspace'
 
 export class UpdateAction implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix]
@@ -13,7 +14,7 @@ export class UpdateAction implements vscode.CodeActionProvider {
     document: vscode.TextDocument,
     range: vscode.Range,
   ): vscode.CodeAction[] | undefined {
-    if (isPackageJson(document) === false) {
+    if (isPackageJson(document) === false && isPnpmWorkspaceFile(document) === false) {
       return
     }
 
@@ -21,7 +22,10 @@ export class UpdateAction implements vscode.CodeActionProvider {
       return
     }
 
-    const dep = getDependencyFromLine(document.getText(), range.start.line, document.uri.fsPath)
+    const text = document.getText()
+    const dep = isPnpmWorkspaceFile(document)
+      ? getWorkspaceDependencyFromLine(text, range.start.line)
+      : getDependencyFromLine(text, range.start.line, document.uri.fsPath)
     // Skip quick-fix upgrades for missing/workspace/catalog dependencies
     if (dep === undefined || dep.isWorkspace === true || dep.isCatalog === true) {
       return

--- a/src/updateAll.ts
+++ b/src/updateAll.ts
@@ -2,8 +2,9 @@ import * as vscode from 'vscode'
 
 import { getIgnorePattern, isDependencyIgnored } from './ignorePattern'
 import { getCachedNpmData, getExactVersion, getLatestVersion } from './npm'
-import { getDependencyInformation, isPackageJson } from './packageJson'
+import { getDependencyInformation, isPackageJson, isPnpmWorkspaceFile } from './packageJson'
 import { replaceLastOccuranceOf } from './util/util'
+import { getWorkspaceFileDependencyInformation } from './workspace'
 
 export interface UpdateEdit {
   range: vscode.Range
@@ -17,12 +18,16 @@ export const updateAll = (textEditor?: vscode.TextEditor): UpdateEdit[] => {
 
   const document = textEditor.document
 
-  if (isPackageJson(document)) {
+  if (isPackageJson(document) || isPnpmWorkspaceFile(document)) {
     const ignorePatterns = getIgnorePattern()
 
-    const dependencies = getDependencyInformation(document.getText(), document.uri.fsPath)
-      .map((d) => d.deps)
-      .flat()
+    const dependencies = isPnpmWorkspaceFile(document)
+      ? getWorkspaceFileDependencyInformation(document.getText())
+          .map((d) => d.deps)
+          .flat()
+      : getDependencyInformation(document.getText(), document.uri.fsPath)
+          .map((d) => d.deps)
+          .flat()
     const edits: UpdateEdit[] = dependencies
       .map((dep) => {
         const lineText = document.lineAt(dep.line).text

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,6 +3,8 @@ import * as yaml from 'js-yaml'
 import * as path from 'path'
 import { globSync } from 'tinyglobby'
 
+import type { Dependency, DependencyGroups } from './packageJson'
+
 interface WorkspaceCache {
   packages: Map<string, string>
   mtime: number
@@ -245,6 +247,107 @@ const parseWorkspaceCatalogs = (content: string): WorkspaceCatalog => {
   return { default: catalog, named }
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> => {
+export const getWorkspaceFileDependencyInformation = (content: string): DependencyGroups[] => {
+  try {
+    const parsed = yaml.load(content)
+    if (!isRecord(parsed)) {
+      return []
+    }
+
+    const lines = content.split('\n')
+    const usedLines = new Set<number>()
+
+    const findLine = (name: string, version: string): number => {
+      const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const regex = new RegExp(
+        `^\\s*["']?${escapedName}["']?:\\s*["']?${escapedVersion}["']?\\s*(?:#.*)?$`,
+      )
+      for (let i = 0; i < lines.length; i++) {
+        if (!usedLines.has(i) && regex.test(lines[i])) {
+          usedLines.add(i)
+          return i
+        }
+      }
+      return -1
+    }
+
+    const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+    const findSectionLine = (name: string, parentName?: string): number => {
+      const regex = new RegExp(`^\\s*${escapeRegex(name)}:\\s*(?:#.*)?$`)
+      let startIndex = 0
+      if (parentName !== undefined) {
+        const parentRegex = new RegExp(`^\\s*${escapeRegex(parentName)}:\\s*(?:#.*)?$`)
+        startIndex = lines.findIndex((line) => parentRegex.test(line))
+        if (startIndex === -1) {
+          return -1
+        }
+        startIndex += 1
+      }
+      for (let i = startIndex; i < lines.length; i++) {
+        if (regex.test(lines[i])) {
+          return i
+        }
+      }
+      return -1
+    }
+
+    const groups: DependencyGroups[] = []
+
+    if (isRecord(parsed.catalog)) {
+      const deps: Dependency[] = []
+      for (const [name, version] of Object.entries(parsed.catalog)) {
+        if (typeof version === 'string') {
+          const line = findLine(name, version)
+          if (line !== -1) {
+            deps.push({ dependencyName: name, currentVersion: version, line })
+          }
+        }
+      }
+      const sectionLine = findSectionLine('catalog')
+      if (deps.length > 0 && sectionLine !== -1) {
+        groups.push({ startLine: sectionLine, deps })
+      }
+    }
+
+    if (isRecord(parsed.catalogs)) {
+      for (const [catalogName, entries] of Object.entries(parsed.catalogs)) {
+        if (isRecord(entries)) {
+          const deps: Dependency[] = []
+          for (const [name, version] of Object.entries(entries)) {
+            if (typeof version === 'string') {
+              const line = findLine(name, version)
+              if (line !== -1) {
+                deps.push({ dependencyName: name, currentVersion: version, line })
+              }
+            }
+          }
+          const sectionLine = findSectionLine(catalogName, 'catalogs')
+          if (deps.length > 0 && sectionLine !== -1) {
+            groups.push({ startLine: sectionLine, deps })
+          }
+        }
+      }
+    }
+
+    return groups
+  } catch {
+    return []
+  }
+}
+
+export const getWorkspaceDependencyFromLine = (
+  content: string,
+  line: number,
+): Dependency | undefined => {
+  const dependencies = getWorkspaceFileDependencyInformation(content)
+    .map((d) => d.deps)
+    .flat()
+
+  return dependencies.find((d) => d.line === line)
+}
+
+export const isRecord = (value: unknown): value is Record<string, unknown> => {
   return value != null && typeof value === 'object' && !Array.isArray(value)
 }


### PR DESCRIPTION
Hi @pgsandstrom — thanks again for merging and releasing v3.6.0 so quickly. Really appreciated.

While using the new workspace support, I noticed a UX gap: **upgrade decorations don't appear in `pnpm-workspace.yaml` itself.** Since this file is where people centralise dependency versions via `catalog:` and `catalogs:`, it felt like a natural place for the extension to surface available updates. Right now users have to open individual `package.json` files to see what's out of date, which defeats the purpose of centralised catalog management.

### What this PR does
- Activates the extension on YAML files and detects `pnpm-workspace.yaml` / `.yml`
- Extracts dependencies from `catalog` and `catalogs.*` sections
- Shows the same upgrade decorations, quick-fixes, and "update all" behaviour that already exist for `package.json`

### Implementation approach
The tricky part is getting line numbers from YAML. `js-yaml` gives us the structure but not source positions, so the approach is:

1. Parse structure with `js-yaml` (robust, already a dependency)
2. Map each extracted dependency back to its line using a lightweight regex scan

The regex handles quoted keys/values and inline comments. For duplicate dependency names across different catalogs, a `usedLines` Set tracks which lines have already been claimed.

### Tradeoffs I considered

| Approach | Pros | Cons | Chosen? |
|----------|------|------|---------|
| **js-yaml + regex line mapper** | Zero new deps; structure parsing is battle-tested | Regex assumes single-line `name: version` pairs (always true for pnpm catalogs) | ✅ Yes |
| js-yaml low-level Composer API | Native line numbers | Not part of the stable public API | ❌ No |
| Add `yaml` package (different library) | Full CST with positions | Extra dependency just for line numbers | ❌ No |
| Manual line-by-line state machine | No deps | Exactly what you rightly called fragile in the last PR | ❌ No |

### One specific question for you
I reused the existing `UpdateAction` provider instance for both `package.json` and workspace file selectors. This keeps the fix/update logic in one place but means the provider receives both file types. An alternative would be separate providers per file type. Any preference on your end?

Happy to make any changes you'd like. Thanks for your time — and thanks again to @michaelfaith for the thorough review on #68.
